### PR TITLE
Lots of fixes to make library compile under 2.5.1.1 (and 2.5.1.2)

### DIFF
--- a/Categories/2-Category.agda
+++ b/Categories/2-Category.agda
@@ -16,7 +16,7 @@ open import Categories.Bifunctor using (Bifunctor; reduce-×)
 open import Categories.Product using (assocʳ; πˡ; πʳ)
 
 record 2-Category (o ℓ t e : Level) : Set (suc (o ⊔ ℓ ⊔ t ⊔ e)) where
-  open Terminal (Categories ℓ t e) (One {ℓ} {t} {e})
+  open Terminal (One {ℓ} {t} {e})
 
   infix  4 _⇒_
   infixr 9 _∘_

--- a/Categories/Colimit.agda
+++ b/Categories/Colimit.agda
@@ -16,7 +16,7 @@ record Colimit {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category
   field
     initial : Initial (Cocones F)
   
-  module I = Initial (Cocones F) initial
+  module I = Initial initial
   module Ic = Cocone I.⊥
   private module C = Category C
 

--- a/Categories/Cone.agda
+++ b/Categories/Cone.agda
@@ -35,7 +35,7 @@ module ConeOver {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Categor
       { N-≣ = ≣-sym X≜Y.N-≣
       ; ψ-≡ = λ j → sym (X≜Y.ψ-≡ j)
       }
-    ; trans = λ X≜Y Y≜Z → 
+    ; trans = λ X≜Y Y≜Z →
       let module X≜Y = _≜_ X≜Y in
       let module Y≜Z = _≜_ Y≜Z in
       record
@@ -79,7 +79,7 @@ module ConeOver {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Categor
     ; sym = λ X≜′Y → let module X≜′Y = _≜′_ X≜′Y in record
       { ψ′-≡ = λ j → Equiv.sym (X≜′Y.ψ′-≡ j)
       }
-    ; trans = λ X≜′Y Y≜′Z → 
+    ; trans = λ X≜′Y Y≜′Z →
       let module X≜′Y = _≜′_ X≜′Y in
       let module Y≜′Z = _≜′_ Y≜′Z in
       record { ψ′-≡ = λ j → Equiv.trans (X≜′Y.ψ′-≡ j) (Y≜′Z.ψ′-≡ j) }

--- a/Categories/Cone.agda
+++ b/Categories/Cone.agda
@@ -119,4 +119,4 @@ module ConeOver {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Categor
 
 open ConeOver public using (cone-setoid) renaming (_≜_ to _[_≜_]; Cone′ to Cone; _≜′_ to _[_≜′_]; ConeUnder′ to ConeUnder)
 
-module Cone {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o′ ℓ′ e′} {F : Functor J C} (K : ConeOver.Cone F) = ConeOver.Cone F K
+module Cone {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o′ ℓ′ e′} {F : Functor J C} (K : ConeOver.Cone F) = ConeOver.Cone K

--- a/Categories/Cones.agda
+++ b/Categories/Cones.agda
@@ -20,7 +20,7 @@ record ConeMorphism {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Cat
     .commute : ∀ {X} → c₁.ψ X ≡ c₂.ψ X ∘ f
 
 Cones : ∀ {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o′ ℓ′ e′} (F : Functor J C) → Category (o ⊔ ℓ ⊔ e ⊔ o′ ⊔ ℓ′) (ℓ ⊔ e ⊔ o′ ⊔ ℓ′) e
-Cones {C = C} F = record 
+Cones {C = C} F = record
   { Obj = Obj′
   ; _⇒_ = Hom′
   ; _≡_ = _≡′_
@@ -29,7 +29,7 @@ Cones {C = C} F = record
   ; assoc = assoc
   ; identityˡ = identityˡ
   ; identityʳ = identityʳ
-  ; equiv = record 
+  ; equiv = record
     { refl = Equiv.refl
     ; sym = Equiv.sym
     ; trans = Equiv.trans
@@ -54,13 +54,13 @@ Cones {C = C} F = record
   F ≡′ G = f F ≡ f G
 
   _∘′_ : ∀ {A B C} → Hom′ B C → Hom′ A B → Hom′ A C
-  _∘′_ {A} {B} {C} F G = record 
+  _∘′_ {A} {B} {C} F G = record
     { f = f F ∘ f G
     ; commute = commute′
     }
     where
     .commute′ : ∀ {X} → ψ A X ≡ ψ C X ∘ (f F ∘ f G)
-    commute′ {X} = 
+    commute′ {X} =
         begin
           ψ A X
         ↓⟨ ConeMorphism.commute G ⟩
@@ -109,7 +109,7 @@ module Float {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o
   morphism-determines-cone-morphism-≣ {A} {B} {m} {m′} pf = lemma₁ A B pf (ConeMorphism.commute m) (ConeMorphism.commute m′)
 
   float₂ : ∀ {A A′ B B′} → F [ A ≜ A′ ] → F [ B ≜ B′ ] → Cones F [ A , B ] → Cones F [ A′ , B′ ]
-  float₂ A≜A′ B≜B′ κ = record 
+  float₂ A≜A′ B≜B′ κ = record
     { f = H.float₂ (N-≣ A≜A′) (N-≣ B≜B′) f
     ; commute = λ {j} → ∼⇒≡ (trans (sym (ψ-≡ A≜A′ j)) (trans (≡⇒∼ commute) (∘-resp-∼ (ψ-≡ B≜B′ j) (float₂-resp-∼ (N-≣ A≜A′) (N-≣ B≜B′)))))
     }
@@ -118,7 +118,7 @@ module Float {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o
     open ConeOver._≜_
 
   floatˡ : ∀ {A B B′} → F [ B ≜ B′ ] → Cones F [ A , B ] → Cones F [ A , B′ ]
-  floatˡ {A = A} B≜B′ κ = record 
+  floatˡ {A = A} B≜B′ κ = record
     { f = H.floatˡ N-≣ f
     ; commute = λ {j} → C.Equiv.trans commute (∼⇒≡ (∘-resp-∼ (ψ-≡ j) (floatˡ-resp-∼ N-≣)))
     }
@@ -138,7 +138,7 @@ module Float {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o
     open ConeMorphism κ
 
   floatʳ : ∀ {A A′ B} → F [ A ≜ A′ ] → Cones F [ A , B ] → Cones F [ A′ , B ]
-  floatʳ {B = B} A≜A′ κ = record 
+  floatʳ {B = B} A≜A′ κ = record
     { f = ≣-subst (λ X → C [ X , B.N ]) N-≣ f
     ; commute = λ {j} → ∼⇒≡ (trans (sym (ψ-≡ j)) (trans (≡⇒∼ commute) (∘-resp-∼ʳ (floatʳ-resp-∼ N-≣))))
     }

--- a/Categories/Cones.agda
+++ b/Categories/Cones.agda
@@ -115,7 +115,7 @@ module Float {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o
     }
     where
     open ConeMorphism κ
-    open ConeOver._≜_ F
+    open ConeOver._≜_
 
   floatˡ : ∀ {A B B′} → F [ B ≜ B′ ] → Cones F [ A , B ] → Cones F [ A , B′ ]
   floatˡ {A = A} B≜B′ κ = record 
@@ -125,7 +125,7 @@ module Float {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o
     where
     module A = Cone A
     open ConeMorphism κ
-    open ConeOver._≜_ F B≜B′
+    open ConeOver._≜_ B≜B′
 
   floatˡ-resp-refl : ∀ {A B} (κ : Cones F [ A , B ]) → floatˡ {A} {B} (ConeOver.≜-refl F) κ ≣ κ
   floatˡ-resp-refl f = ≣-refl
@@ -134,7 +134,7 @@ module Float {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o
   floatˡ-resp-trans {A} {B} {B′} {B″} B≜B′ B′≜B″ κ = morphism-determines-cone-morphism-≣ {A} {B″} {floatˡ {A} {B} {B″} (ConeOver.≜-trans F B≜B′ B′≜B″) κ} {floatˡ {A} {B′} {B″} B′≜B″ (floatˡ {A} {B} {B′} B≜B′ κ)} (H.floatˡ-resp-trans (N-≣ B≜B′) (N-≣ B′≜B″) f)
     where
     module A = Cone A
-    open ConeOver._≜_ F
+    open ConeOver._≜_
     open ConeMorphism κ
 
   floatʳ : ∀ {A A′ B} → F [ A ≜ A′ ] → Cones F [ A , B ] → Cones F [ A′ , B ]
@@ -145,12 +145,12 @@ module Float {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o
     where
     module B = Cone B
     open ConeMorphism κ
-    open ConeOver._≜_ F A≜A′
+    open ConeOver._≜_ A≜A′
 
   float₂-breakdown-lr : ∀ {A A′ B B′ : Cone F} (A≜A′ : F [ A ≜ A′ ]) (B≜B′ : F [ B ≜ B′ ]) (κ : Cones F [ A , B ]) → float₂ A≜A′ B≜B′ κ ≣ floatˡ B≜B′ (floatʳ A≜A′ κ)
   float₂-breakdown-lr {A′ = A′} {B′ = B′} A≜A′ B≜B′ κ = morphism-determines-cone-morphism-≣ {A = A′} {B′} {float₂ A≜A′ B≜B′ κ} {floatˡ B≜B′ (floatʳ A≜A′ κ)} (H.float₂-breakdown-lr (N-≣ A≜A′) (N-≣ B≜B′) (ConeMorphism.f κ))
-    where open ConeOver._≜_ F
+    where open ConeOver._≜_
 
   float₂-breakdown-rl : ∀ {A A′ B B′ : Cone F} (A≜A′ : F [ A ≜ A′ ]) (B≜B′ : F [ B ≜ B′ ]) (κ : Cones F [ A , B ]) → float₂ A≜A′ B≜B′ κ ≣ floatʳ A≜A′ (floatˡ B≜B′ κ)
   float₂-breakdown-rl {A′ = A′} {B′ = B′} A≜A′ B≜B′ κ = morphism-determines-cone-morphism-≣ {A = A′} {B′} {float₂ A≜A′ B≜B′ κ} {floatʳ A≜A′ (floatˡ B≜B′ κ)} (H.float₂-breakdown-rl (N-≣ A≜A′) (N-≣ B≜B′) (ConeMorphism.f κ))
-    where open ConeOver._≜_ F
+    where open ConeOver._≜_

--- a/Categories/DinaturalTransformation.agda
+++ b/Categories/DinaturalTransformation.agda
@@ -34,7 +34,26 @@ record DinaturalTransformation {o ℓ e o′ ℓ′ e′}
 
 _<∘_ : ∀ {o ℓ e o′ ℓ′ e′} {C : Category o ℓ e} {D : Category o′ ℓ′ e′} {F G H : Bifunctor (Category.op C) C D}
       → NT.NaturalTransformation G H → DinaturalTransformation {C = C} F G → DinaturalTransformation {C = C} F H
-_<∘_ {C = C} {D} {F} {G} {H} eta alpha = record { α = λ c → η (c , c) ∘ α c; commute = λ {c} {c′} f →
+_<∘_ {C = C} {D} {F} {G} {H} eta alpha = record { α = λ c → η (c , c) ∘ α c; commute = λ {c} {c′} f → 
+     begin
+       H.F₁ (f , C.id) ∘ ((η (c′ , c′) ∘ α c′) ∘ F.F₁ (C.id , f))
+     ↓⟨ ∘-resp-≡ʳ assoc ⟩
+       H.F₁ (f , C.id) ∘ (η (c′ , c′) ∘ (α c′ ∘ F.F₁ (C.id , f)))
+     ↑⟨ assoc ⟩
+       (H.F₁ (f , C.id) ∘ η (c′ , c′)) ∘ (α c′ ∘ F.F₁ (C.id , f))
+     ↑⟨ ∘-resp-≡ˡ (eta.commute (f , C.id)) ⟩
+       (η (c , c′) ∘ G.F₁ (f , C.id)) ∘ (α c′ ∘ F.F₁ (C.id , f))
+     ↓⟨ pullʳ (commute f) ⟩
+       η (c , c′) ∘ G.F₁ (C.id , f) ∘ (α c ∘ F.F₁ (f , C.id))
+     ↓⟨ pullˡ (eta.commute (C.id , f)) ⟩
+       (H.F₁ (C.id , f) ∘ η (c , c)) ∘ (α c ∘ F.F₁ (f , C.id))
+     ↓⟨ assoc ⟩
+       H.F₁ (C.id , f) ∘ (η (c , c) ∘ (α c ∘ F.F₁ (f , C.id)))
+     ↑⟨ ∘-resp-≡ʳ assoc ⟩
+       H.F₁ (C.id , f) ∘ ((η (c , c) ∘ α c) ∘ F.F₁ (f , C.id))
+     ∎
+{-  This uses 'associative-unital reasoning, which is now broken.  Above uses
+    direct reasoning, which is heavier, but works.  JC.
      begin
        H.F₁ (f , C.id) ∙ ((η (c′ , c′) ∙ α c′) ∙ F.F₁ (C.id , f))
      ↑⟨ refl ⟩
@@ -47,7 +66,7 @@ _<∘_ {C = C} {D} {F} {G} {H} eta alpha = record { α = λ c → η (c , c) ∘
        (H.F₁ (C.id , f) ∙ η (c , c)) ∙ α c ∙ F.F₁ (f , C.id)
      ↓⟨ refl ⟩
        H.F₁ (C.id , f) ∙ (η (c , c) ∙ α c) ∙ F.F₁ (f , C.id)
-     ∎ }
+     ∎ -} }
   where
     module C = Category C
     module D = Category D
@@ -59,7 +78,8 @@ _<∘_ {C = C} {D} {F} {G} {H} eta alpha = record { α = λ c → η (c , c) ∘
     module eta = NT.NaturalTransformation eta
     open eta using (η)
     open DinaturalTransformation alpha
-    open AUReasoning D
+    -- open AUReasoning D
+    open HomReasoning
     open GlueSquares D
 
 _∘>_ : ∀ {o ℓ e o′ ℓ′ e′} {C : Category o ℓ e} {D : Category o′ ℓ′ e′} {F G H : Bifunctor (Category.op C) C D}

--- a/Categories/End.agda
+++ b/Categories/End.agda
@@ -20,25 +20,46 @@ record End-data (F : Bifunctor C.op C V) : Set (o ⊔ ℓ ⊔ e ⊔ o′ ⊔ ℓ
   module π = DinaturalTransformation π
   open π using (α)
   π∘_ : ∀ {Q} → Q V.⇒ E → End-data F
-  π∘ g = record { π = record { α = λ c → α c ∘ g; commute = λ {c c′} f →
-          begin
-            F.F₁ (f , C.id) ∙ (α c′ ∙ g) ∙ ID ↓⟨ Equiv.refl ⟩
+  π∘_ {Q} g = record { π = record { α = λ c → α c ∘ g; commute = λ {c c′} f → 
+               begin
+                  F.F₁ (f , C.id) ∘ ((α c′ ∘ g) ∘ id)
+                ↓⟨ ∘-resp-≡ʳ identityʳ ⟩
+                  F.F₁ (f , C.id) ∘ (α c′ ∘ g)
+                ↑⟨ assoc ⟩
+                  (F.F₁ (f , C.id) ∘ α c′) ∘ g
+                ↑⟨ ∘-resp-≡ʳ identityˡ ⟩
+                  (F.F₁ (f , C.id) ∘ α c′) ∘ (id ∘ g)
+                ↑⟨ assoc ⟩
+                  ((F.F₁ (f , C.id) ∘ α c′) ∘ id) ∘ g
+                ↓⟨ ∘-resp-≡ˡ assoc ⟩
+                  (F.F₁ (f , C.id) ∘ (α c′ ∘ id)) ∘ g
+                ↓⟨ ∘-resp-≡ˡ (π.commute f) ⟩
+                  (F.F₁ (C.id , f) ∘ (α c ∘ id)) ∘ g
+                ↓⟨ assoc ⟩
+                  F.F₁ (C.id , f) ∘ (α c ∘ id) ∘ g
+                ↓⟨ ∘-resp-≡ʳ (∘-resp-≡ˡ identityʳ) ⟩
+                  F.F₁ (C.id , f) ∘ α c ∘ g
+                ↑⟨ ∘-resp-≡ʳ identityʳ ⟩
+                  F.F₁ (C.id , f) ∘ (α c ∘ g) ∘ id ∎
+{-          begin
+            F.F₁ (f , C.id) ∘ (α c′ ∘ g) ∘ ID ↓⟨ Equiv.refl ⟩
             (F.F₁ (f , C.id) ∙ α c′ ∙ ID) ∙ g ↓≡⟨ ∘-resp-≡ˡ (π.commute f) ⟩
             (F.F₁ (C.id , f) ∙ α c ∙ ID) ∙ g  ↓⟨ Equiv.refl ⟩
-            F.F₁ (C.id , f) ∙ (α c ∙ g) ∙ ID  ∎ } }
+            F.F₁ (C.id , f) ∙ (α c ∙ g) ∙ ID  ∎ -} } }
    where
-     open AUReasoning V
+     -- open AUReasoning V
+     open V.HomReasoning
      module F = Functor F
      open V
 
   .commute : ∀ {a b} (f : a C.⇒ b) -> Functor.F₁ F (f , C.id) V.∘ α b V.≡ Functor.F₁ F (C.id , f) V.∘ α a
-  commute {c} {c′} f = begin
-            F.F₁ (f , C.id) ∙ α c′      ↓⟨ Equiv.refl ⟩
-            F.F₁ (f , C.id) ∙ α c′ ∙ ID ↓≡⟨ π.commute f ⟩
-            F.F₁ (C.id , f) ∙ α c  ∙ ID ↓⟨ Equiv.refl ⟩
-            F.F₁ (C.id , f) ∙ α c       ∎
+  commute {c} {c′} f =  begin
+            F.F₁ (f , C.id) ∘ α c′      ↑⟨ ∘-resp-≡ʳ identityʳ ⟩
+            F.F₁ (f , C.id) ∘ α c′ ∘ id ↓⟨ π.commute f ⟩
+            F.F₁ (C.id , f) ∘ α c  ∘ id ↓⟨ ∘-resp-≡ʳ identityʳ ⟩
+            F.F₁ (C.id , f) ∘ α c       ∎ 
     where
-      open AUReasoning V
+      open V.HomReasoning
       module F = Functor F
       open V
 
@@ -90,31 +111,32 @@ endF {A = A} F mke = record {
                    F₀ = λ a → End.E (mke a);
                    F₁ = λ {a b} → F₁ {a} {b} ;
                    identity = λ {a} → V.Equiv.sym (End.universal-unique (mke a) V.id (λ c →
-                     begin α (End.π (mke a)) c ∙ ID                    ↓⟨ Equiv.refl ⟩
-                           ID ∙ α (End.π (mke a)) c                    ↑≡⟨ ∘-resp-≡ˡ F.identity ⟩
-                           η (F.F₁ A.id) (c , c) ∙ α (End.π (mke a)) c ∎)) ;
+                     begin α (End.π (mke a)) c ∘ id                    ↓⟨ identityʳ ⟩
+                           α (End.π (mke a)) c                         ↑⟨ identityˡ ⟩
+                           id ∘ α (End.π (mke a)) c                    ↑⟨ ∘-resp-≡ˡ F.identity ⟩
+                           η (F.F₁ A.id) (c , c) ∘ α (End.π (mke a)) c ∎ )) ;
                    homomorphism = λ {X Y Z f g} → V.Equiv.sym (End.universal-unique (mke Z) _ (λ c →
-                       begin α (End.π (mke Z)) c ∙ F₁ g ∙ F₁ f
-                                   ↑⟨ Equiv.refl ⟩
-                             (α (End.π (mke Z)) c ∙ F₁ g) ∙ F₁ f
-                                   ↓≡⟨ ∘-resp-≡ˡ (End.π[c]∘universal≡δ[c] (mke Z) {record {π = F.F₁ g <∘ End.π (mke Y)}} c) ⟩
-                             (η (F.F₁ g) (c , c) ∙ α (End.π (mke Y)) c) ∙ F₁ f
-                                   ↓⟨ Equiv.refl ⟩
-                             η (F.F₁ g) (c , c) ∙ α (End.π (mke Y)) c ∙ F₁ f
-                                   ↓≡⟨ ∘-resp-≡ʳ (End.π[c]∘universal≡δ[c] (mke Y) {record {π = F.F₁ f <∘ End.π (mke X)}} c) ⟩
-                             η (F.F₁ g) (c , c) ∙ η (F.F₁ f) (c , c) ∙ α (End.π (mke X)) c
-                                   ↑⟨ Equiv.refl ⟩
-                             (η (F.F₁ g) (c , c) ∙ η (F.F₁ f) (c , c)) ∙ α (End.π (mke X)) c
-                                   ↑≡⟨ ∘-resp-≡ˡ F.homomorphism  ⟩
-                             η (F.F₁ (A [ g ∘ f ])) (c , c) ∙ α (End.π (mke X)) c
-                                                                                   ∎));
-                   F-resp-≡ = λ {a b f g} f≡g → End.universal-unique (mke b) _ (λ c →
-                       begin α (End.π (mke b)) c ∙ F₁ f               ↓≡⟨ End.π[c]∘universal≡δ[c] (mke b) c ⟩
-                             η (F.F₁ f) (c , c) ∙ α (End.π (mke a)) c ↓≡⟨ ∘-resp-≡ˡ (F.F-resp-≡ f≡g) ⟩
-                             η (F.F₁ g) (c , c) ∙ α (End.π (mke a)) c ∎)}
+                       begin α (End.π (mke Z)) c ∘ F₁ g ∘ F₁ f
+                                   ↑⟨ assoc ⟩
+                             (α (End.π (mke Z)) c ∘ F₁ g) ∘ F₁ f
+                                   ↓⟨ ∘-resp-≡ˡ (End.π[c]∘universal≡δ[c] (mke Z) {record {π = F.F₁ g <∘ End.π (mke Y)}} c) ⟩
+                             (η (F.F₁ g) (c , c) ∘ α (End.π (mke Y)) c) ∘ F₁ f
+                                   ↓⟨ assoc ⟩
+                             η (F.F₁ g) (c , c) ∘ α (End.π (mke Y)) c ∘ F₁ f
+                                   ↓⟨ ∘-resp-≡ʳ (End.π[c]∘universal≡δ[c] (mke Y) {record {π = F.F₁ f <∘ End.π (mke X)}} c) ⟩
+                             η (F.F₁ g) (c , c) ∘ η (F.F₁ f) (c , c) ∘ α (End.π (mke X)) c
+                                   ↑⟨ assoc ⟩
+                             (η (F.F₁ g) (c , c) ∘ η (F.F₁ f) (c , c)) ∘ α (End.π (mke X)) c
+                                   ↑⟨ ∘-resp-≡ˡ F.homomorphism  ⟩
+                             η (F.F₁ (A [ g ∘ f ])) (c , c) ∘ α (End.π (mke X)) c
+                                                                                   ∎ ));
+                   F-resp-≡ = λ {a b f g} f≡g → End.universal-unique (mke b) _ (λ c → 
+                          begin α (End.π (mke b)) c ∘ F₁ f               ↓⟨ End.π[c]∘universal≡δ[c] (mke b) c ⟩
+                                η (F.F₁ f) (c , c) ∘ α (End.π (mke a)) c ↓⟨ ∘-resp-≡ˡ (F.F-resp-≡ f≡g) ⟩
+                                η (F.F₁ g) (c , c) ∘ α (End.π (mke a)) c ∎ ) }
  where
   module A = Category A
   module F = Functor F
   open V
-  open AUReasoning V
+  open V.HomReasoning
   F₁ = λ {a b} f → End.universal (mke b) (record { E = _; π = (F.F₁ f) <∘ (End.π (mke a)) })

--- a/Categories/Functor/Algebras.agda
+++ b/Categories/Functor/Algebras.agda
@@ -101,7 +101,7 @@ module Lambek {o ℓ e} {C : Category o ℓ e} {F : Endofunctor C} (I : Initial 
   open Functor F
   import Categories.Morphisms as Morphisms
   open Morphisms C
-  open Initial (F-Algebras F) I
+  open Initial I
   open F-Algebra ⊥
 
   lambek : A ≅ F₀ A

--- a/Categories/Functor/Product.agda
+++ b/Categories/Functor/Product.agda
@@ -19,7 +19,7 @@ C [ P ][ O ×-] = record
   open Category C
   open Equiv
   open Product C
-  open BinaryProducts.BinaryProducts C P
+  open BinaryProducts.BinaryProducts P
 
   .identity′ : {A : Obj} → ⟨ π₁ , id ∘ π₂ ⟩ ≡ id
   identity′ = 
@@ -59,7 +59,7 @@ C [ P ][-× O ] = record
   open Category C
   open Equiv
   open Product C
-  open BinaryProducts.BinaryProducts C P
+  open BinaryProducts.BinaryProducts P
 
   .identity′ : {A : Obj} → ⟨ id ∘ π₁ , π₂ ⟩ ≡ id
   identity′ = 

--- a/Categories/Functor/Properties.agda
+++ b/Categories/Functor/Properties.agda
@@ -35,7 +35,7 @@ module FunctorsAlways {o ℓ e o′ ℓ′ e′} {C : Category o ℓ e} {D : Cat
              ∎
     }
     where
-    module I = Morphisms.Iso C I
+    module I = Morphisms.Iso I
     open D.HomReasoning
 
   resp-≅ : F₀ Preserves Morphisms._≅_ C ⟶ Morphisms._≅_ D
@@ -45,4 +45,4 @@ module FunctorsAlways {o ℓ e o′ ℓ′ e′} {C : Category o ℓ e} {D : Cat
     ; iso = resp-Iso I.iso
     }
     where
-    module I = Morphisms._≅_ C I
+    module I = Morphisms._≅_ I

--- a/Categories/Limit.agda
+++ b/Categories/Limit.agda
@@ -15,7 +15,7 @@ open import Categories.Cone using (module Cone; module ConeOver)
 
 module LimitsOf {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Category o′ ℓ′ e′} (F : Functor J C) where
 
-  private module L = Terminal (Cones F)
+  private module L = Terminal
 
   open Category C
   open Category J using () renaming (Obj to Dot)
@@ -31,7 +31,7 @@ module LimitsOf {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Categor
     field
       terminal : Terminal (Cones F)
 
-    private module terminal = Terminal (Cones F) terminal
+    private module terminal = Terminal terminal
     module Fl = Float F
 
     {-
@@ -156,7 +156,7 @@ module LimitsOf {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Categor
       ; iso = record { isoˡ = isoˡ; isoʳ = isoʳ }
       }
     where
-    open Mor._≅_ C κ≅v
+    open Mor._≅_ κ≅v
     open GlueSquares C
 
   isos-lower-from-cones : ∀ {κ₁ κ₂ : Cone} → κ₁ ⇿ κ₂ → Cone.N κ₁ ≅ Cone.N κ₂
@@ -166,12 +166,12 @@ module LimitsOf {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Categor
     ; iso = record { isoˡ = isoˡ; isoʳ = isoʳ }
     }
     where
-    open Mor._≅_ (Cones F) κ₁⇿κ₂
+    open Mor._≅_ κ₁⇿κ₂
 
   ≜ⁱ⇒≡ⁱ : ∀ {κ₁ κ₂} {i₁ i₂ : κ₁ ⇿ κ₂} → i₁ ≜ⁱ i₂
         → isos-lower-from-cones i₁ ≡ⁱ isos-lower-from-cones i₂
   ≜ⁱ⇒≡ⁱ pf = record { f-≡ = f-≡; g-≡ = g-≡ }
-    where open Mor._≡ⁱ_ (Cones F) pf
+    where open Mor._≡ⁱ_ pf
 
   up-to-iso-cone : (L₁ L₂ : Limit) → proj-cone L₁ ⇿ proj-cone L₂
   up-to-iso-cone L₁ L₂ = T.up-to-iso (Cones F) (terminal L₁) (terminal L₂)
@@ -199,8 +199,7 @@ module LimitsOf {o ℓ e} {o′ ℓ′ e′} {C : Category o ℓ e} {J : Categor
   up-to-iso-cone-invˡ {L} {i = i} = up-to-iso-cone-unique L (transport-by-iso-cone L i) i
 
   .up-to-iso-invˡ : ∀ {L X} {i : vertex L ≅ X} → up-to-iso L (transport-by-iso L i) ≡ⁱ i
-  up-to-iso-invˡ {L} {i = i} = ≜ⁱ⇒≡ⁱ (up-to-iso-cone-invˡ {L} {i = proj₂ p})
-    where p = isos-lift-to-cones (proj-cone L) i
+  up-to-iso-invˡ {L₁} {i = i} = ≜ⁱ⇒≡ⁱ (up-to-iso-cone-invˡ {L₁} {i = proj₂ (isos-lift-to-cones (proj-cone L₁) i)})
 
   up-to-iso-cone-invʳ : ∀ {L L′} → proj-cone (transport-by-iso-cone L (up-to-iso-cone L L′)) ≜ proj-cone L′
   up-to-iso-cone-invʳ {L} {L′} = ≜-refl

--- a/Categories/Monoidal/Cartesian.agda
+++ b/Categories/Monoidal/Cartesian.agda
@@ -62,11 +62,11 @@ Cartesian C Ps = record
   where
   open Categories.Morphisms C
   open Category C
-  open Products C Ps renaming (terminal to T₀; binary to P₀)
+  open Products Ps renaming (terminal to T₀; binary to P₀)
   open ProductProperties C Ps
-  open Terminal C T₀ using (⊤; !; !-unique; !-unique₂)
+  open Terminal T₀ using (⊤; !; !-unique; !-unique₂)
 
-  open BinaryProducts C P₀
+  open BinaryProducts P₀
   open Pentagon.Law C P₀ using (pentagon)
 
   ⊗ : Bifunctor C C C

--- a/Categories/Monoidal/Cartesian/Pentagon.agda
+++ b/Categories/Monoidal/Cartesian/Pentagon.agda
@@ -8,7 +8,7 @@ open import Categories.Square
 
 module Law {o ℓ e} (C : Category o ℓ e) (P : BinaryProducts C) where
   open Category C
-  open BinaryProducts C P
+  open BinaryProducts P
 
   shave3ˡ : ∀ {A B C} → ((A × B) × C) ⇒ (B × C)
   shave3ˡ = ⟨ π₂ ∘ π₁ , π₂ ⟩ -- in real life, 'first π₂'

--- a/Categories/Morphisms.agda
+++ b/Categories/Morphisms.agda
@@ -172,15 +172,15 @@ private
     open _≡ⁱ_
 
 -- fake record
-module _∼ⁱ_ {A B} {i : A ≅ B} {A′ B′} {j : A′ ≅ B′} (eq : i ∼ⁱ j) where
-  open _≅_
-  open Heterogeneous C
+-- module _∼ⁱ_ {A B} {i : A ≅ B} {A′ B′} {j : A′ ≅ B′} (eq : i ∼ⁱ j) where
+--   open _≅_
+--   open Heterogeneous C
 
-  f-∼ : f i ∼ f j
-  f-∼ = f-∼′ eq
+--   f-∼ : f i ∼ f j
+--   f-∼ = f-∼′ eq
 
-  g-∼ : g i ∼ g j
-  g-∼ = g-∼′ eq
+--   g-∼ : g i ∼ g j
+--   g-∼ = g-∼′ eq
 
 
 heqⁱ : ∀ {A B} (i : A ≅ B) {A′ B′} (j : A′ ≅ B′) → let open _≅_ in let open Heterogeneous C in f i ∼ f j → g i ∼ g j → i ∼ⁱ j

--- a/Categories/Morphisms.agda
+++ b/Categories/Morphisms.agda
@@ -171,18 +171,6 @@ private
     open Heterogeneous C
     open _≡ⁱ_
 
--- fake record
--- module _∼ⁱ_ {A B} {i : A ≅ B} {A′ B′} {j : A′ ≅ B′} (eq : i ∼ⁱ j) where
---   open _≅_
---   open Heterogeneous C
-
---   f-∼ : f i ∼ f j
---   f-∼ = f-∼′ eq
-
---   g-∼ : g i ∼ g j
---   g-∼ = g-∼′ eq
-
-
 heqⁱ : ∀ {A B} (i : A ≅ B) {A′ B′} (j : A′ ≅ B′) → let open _≅_ in let open Heterogeneous C in f i ∼ f j → g i ∼ g j → i ∼ⁱ j
 heqⁱ i j (Heterogeneous.≡⇒∼ eq-f) (Heterogeneous.≡⇒∼ eq-g)
   = ≡⇒∼ⁱ {f = i} {g = j} (record { f-≡ = eq-f; g-≡ = eq-g })

--- a/Categories/NaturalIsomorphism.agda
+++ b/Categories/NaturalIsomorphism.agda
@@ -149,6 +149,7 @@ _ⓘʳ_ : ∀ {o₀ ℓ₀ e₀ o₁ ℓ₁ e₁ o₂ ℓ₂ e₂}
   module η = NaturalIsomorphism η
   module K = Functor K
 
+{- -- comment this out for now, as it is not crucial for other ongoing work
 ≡→iso : ∀ {o ℓ e o′ ℓ′ e′} {C : Category o ℓ e} {D : Category o′ ℓ′ e′} (F G : Functor C D) → F ≡F G → NaturalIsomorphism F G
 ≡→iso {C = C} {D} F G F≡G =
   record
@@ -209,3 +210,4 @@ _ⓘʳ_ : ∀ {o₀ ℓ₀ e₀ o₁ ℓ₁ e₁ o₂ ℓ₂ e₂}
     module F = Functor F
     module G = Functor G
   my-iso F G F≡G G≡F x | _ | ._ | _ | _ | ≡⇒∼ _ | ≡⇒∼ _ = D.identityʳ
+-}

--- a/Categories/NaturalIsomorphism.agda
+++ b/Categories/NaturalIsomorphism.agda
@@ -47,7 +47,7 @@ equiv {C = C} {D} = record
       ; isoʳ = D.identityˡ
       }
     }
-  ; sym = λ X → let module X Z = Morphisms.Iso D (NaturalIsomorphism.iso X Z) in record
+  ; sym = λ X → let module X Z = Morphisms.Iso (NaturalIsomorphism.iso X Z) in record
     { F⇒G = NaturalIsomorphism.F⇐G X
     ; F⇐G = NaturalIsomorphism.F⇒G X
     ; iso = λ Y → record 
@@ -80,8 +80,8 @@ equiv {C = C} {D} = record
       where
       open NaturalIsomorphism
       open NaturalTransformation
-      module Y Z = Morphisms.Iso D (iso Y Z)
-      module X Z = Morphisms.Iso D (iso X Z)
+      module Y Z = Morphisms.Iso (iso Y Z)
+      module X Z = Morphisms.Iso (iso X Z)
 
       isoˡ′ : (η (F⇐G X) Z ∘ η (F⇐G Y) Z) ∘ (η (F⇒G Y) Z ∘ η (F⇒G X) Z) ≡ D.id
       isoˡ′ = begin

--- a/Categories/Object/BinaryCoproducts.agda
+++ b/Categories/Object/BinaryCoproducts.agda
@@ -171,7 +171,3 @@ Bin→Binary bc = record { coproduct = λ {A} {B} → record {
   where
     open CP.BinCoproducts bc
 
-module BinCoproducts (coprod : BinCoproducts) where
-  open CP.BinCoproducts coprod public
-  open BinaryCoproducts (Bin→Binary coprod) public hiding ([_,_]; i₁; i₂; commute₁; commute₂; universal)
-

--- a/Categories/Object/BinaryProducts/N-ary.agda
+++ b/Categories/Object/BinaryProducts/N-ary.agda
@@ -8,7 +8,7 @@ module Categories.Object.BinaryProducts.N-ary {o ℓ e}
   where
 
 open Category C
-open BinaryProducts C BP
+open BinaryProducts BP
 open Equiv
 
 import Categories.Object.Product

--- a/Categories/Object/Exponential.agda
+++ b/Categories/Object/Exponential.agda
@@ -69,8 +69,8 @@ record Exponential (A B : Obj) : Set (o ⊔ ℓ ⊔ e) where
     where
     open HomReasoning
     open Equiv
-    p₁ = product
     subst-commutes =
+      let p₁ = product in
       begin
           eval ∘ [ p₂ ⇒ p₁ ]first (λg p₃ f ∘ g)
         ↑⟨ refl ⟩∘⟨ [ p₂ ⇒ p₃ ⇒ p₁ ]first∘first ⟩
@@ -134,10 +134,10 @@ open Morphisms C
   open Equiv
   module e₁ = Exponential e₁
   module e₂ = Exponential e₂
-  p₁ = e₁.product
-  p₂ = e₂.product
   
   eval∘second∘first =
+    let p₁ = e₁.product in
+    let p₂ = e₂.product in
     begin
       ([ e₂ ]eval ∘ [ p₅ ⇒ Exponential.product e₂ ]second f) ∘ [ p₃ ⇒ p₅ ]first ([ e₂ ]λ p₄ g)
     ↓⟨ assoc ⟩
@@ -165,7 +165,9 @@ repack e₁ e₂ = e₂.λg e₁.product e₁.eval
 repack≡id e = Exponential.η-id e
 
 .repack∘ : ∀{A B} (e₁ e₂ e₃ : Exponential A B) → repack e₂ e₃ ∘ repack e₁ e₂ ≡ repack e₁ e₃
-repack∘ {A} {B} e₁ e₂ e₃ = 
+repack∘ {A} {B} e₁ e₂ e₃ =
+  let p₁ = product e₁ in
+  let p₂ = product e₂ in
   begin
       [ e₃ ]λ p₂ [ e₂ ]eval
     ∘ [ e₂ ]λ p₁ [ e₁ ]eval
@@ -182,8 +184,6 @@ repack∘ {A} {B} e₁ e₂ e₃ =
     open Exponential
     open HomReasoning
     open GlueSquares C
-    p₁ = product e₁
-    p₂ = product e₂
 
 .repack-cancel : ∀{A B} (e₁ e₂ : Exponential A B) → repack e₁ e₂ ∘ repack e₂ e₁ ≡ id
 repack-cancel e₁ e₂ = Equiv.trans (repack∘ e₂ e₁ e₂) (repack≡id e₂)

--- a/Categories/Object/Exponentiating.agda
+++ b/Categories/Object/Exponentiating.agda
@@ -7,7 +7,7 @@ module Categories.Object.Exponentiating {o ℓ e}
     (binary : BinaryProducts C)  where
 
 open Category C
-open BinaryProducts C binary
+open BinaryProducts binary
 
 import Categories.Object.Product
 open Categories.Object.Product C

--- a/Categories/Object/Exponentiating/Adjunction.agda
+++ b/Categories/Object/Exponentiating/Adjunction.agda
@@ -10,8 +10,8 @@ module Categories.Object.Exponentiating.Adjunction {o ℓ e}
     (exponentiating : Exponentiating C binary Σ) where
 
 open Category C
-open BinaryProducts C binary
-open Exponentiating C binary exponentiating
+open BinaryProducts binary
+open Exponentiating exponentiating
 
 import Categories.Object.Product
 open Categories.Object.Product C

--- a/Categories/Object/Exponentiating/Functor.agda
+++ b/Categories/Object/Exponentiating/Functor.agda
@@ -10,8 +10,8 @@ module Categories.Object.Exponentiating.Functor {o ℓ e}
     (exponentiating : Exponentiating C binary Σ) where
 
 open Category C
-open BinaryProducts C binary
-open Exponentiating C binary exponentiating
+open BinaryProducts binary
+open Exponentiating exponentiating
 
 open Equiv
 open HomReasoning

--- a/Categories/Object/Products/N-ary.agda
+++ b/Categories/Object/Products/N-ary.agda
@@ -8,7 +8,7 @@ module Categories.Object.Products.N-ary {o ℓ e}
   where
 
 open Category C
-open Products C P
+open Products P
 open Equiv
 
 import Categories.Object.Product

--- a/Categories/Object/SubobjectClassifier.agda
+++ b/Categories/Object/SubobjectClassifier.agda
@@ -18,7 +18,7 @@ record SubobjectClassifier : Set (o ⊔ ℓ ⊔ e) where
     χ : ∀ {U X} → (j : U ⇒ X) → (X ⇒ Ω)
     terminal : Terminal C
 
-  open Terminal C terminal
+  open Terminal terminal
 
   field
     ⊤⇒Ω : ⊤ ⇒ Ω

--- a/Categories/Object/Terminal/Exponentials.agda
+++ b/Categories/Object/Terminal/Exponentials.agda
@@ -9,7 +9,7 @@ module Categories.Object.Terminal.Exponentials {o ℓ e : Level}
     (T : Terminal C) where
 
 open Category C
-open Terminal C T
+open Terminal T
 
 import Categories.Object.Exponential
 import Categories.Object.Product

--- a/Categories/Object/Terminal/Exponentiating.agda
+++ b/Categories/Object/Terminal/Exponentiating.agda
@@ -10,8 +10,8 @@ module Categories.Object.Terminal.Exponentiating {o ℓ e : Level}
     (P : Products C) where
 
 open Category C
-open Products C P
-open Terminal C terminal
+open Products P
+open Terminal terminal
 
 open import Categories.Object.Exponentiating
 import Categories.Object.Terminal.Exponentials

--- a/Categories/Object/Terminal/Products.agda
+++ b/Categories/Object/Terminal/Products.agda
@@ -11,7 +11,7 @@ module Categories.Object.Terminal.Products {o ℓ e : Level}
 open import Categories.Object.Product
 
 open Category C
-open Terminal C T
+open Terminal T
 
 [⊤×⊤] : Obj
 [⊤×⊤] = ⊤

--- a/Categories/Opposite.agda
+++ b/Categories/Opposite.agda
@@ -18,7 +18,7 @@ opⁱ {C = C} A≅B = record
   ; iso = record { isoˡ = A≅B.isoʳ; isoʳ = A≅B.isoˡ }
   }
   where
-  module A≅B = _≅_ C A≅B
+  module A≅B = Categories.Morphisms._≅_ A≅B
 
 opF : ∀ {o₁ ℓ₁ e₁ o₂ ℓ₂ e₂} {A : Category o₁ ℓ₁ e₁} {B : Category o₂ ℓ₂ e₂} -> 
     (Functor (Category.op (Functors (Category.op A) (Category.op B))) (Functors A B))

--- a/Categories/Power/Functorial.agda
+++ b/Categories/Power/Functorial.agda
@@ -165,7 +165,13 @@ exp≅functor ext id-propositionally-unique {I} =
   η-under-substʳ α ≣-refl c = ≣-refl
 
   .lemma : (A B : Obj FDIC) (f : FDIC [ A , B ]) (i : I) → C [ η (≣-subst (λ X → FDIC [ X , B ]) (squash-does-nothing A) (≣-subst (λ Y → FDIC [ squash A , Y ]) (squash-does-nothing B) (map₁ f∘g f))) i ≡ η f i ]
-  lemma A B f i = C.Equiv.reflexive (
+  lemma A B f i =
+    let loc X = map₀ X i in
+    let sqdnA = squash-does-nothing A in
+    let sqdnB = squash-does-nothing B in
+    let MESS = ≣-subst (λ Y → FDIC [ squash A , Y ]) sqdnB (map₁ f∘g f) in
+
+    C.Equiv.reflexive (
       begin
         η (≣-subst (λ X → FDIC [ X , B ]) sqdnA MESS) i
       ≣⟨ η-under-substˡ MESS sqdnA i ⟩
@@ -179,13 +185,6 @@ exp≅functor ext id-propositionally-unique {I} =
       ∎)
     where
     open ≣-reasoning
-
-    loc : Obj FDIC → Obj C
-    loc X = map₀ X i
-
-    sqdnA = squash-does-nothing A
-    sqdnB = squash-does-nothing B
-    MESS = ≣-subst (λ Y → FDIC [ squash A , Y ]) sqdnB (map₁ f∘g f)
 
   ir : (A B : Obj FDIC) (f : FDIC [ A , B ]) → FDIC [ map₁ f∘g f ∼ f ]
   ir A B f = ∼-subst {C = FDIC} f (map₁ f∘g f) (squash-does-nothing A) (squash-does-nothing B) (λ {x} → lemma A B f x)

--- a/Categories/Support/SetoidPi.agda
+++ b/Categories/Support/SetoidPi.agda
@@ -158,7 +158,7 @@ asIndexed ct ℓt {From} To = record
   .resp-helper₂ : ∀ {i j} → From [ i ≈ j ] → _≈⋆_ {i} {i} ≅ _≈⋆_ {j} {j}
   resp-helper₂ {i} {j} i∼j = resp-helper₃ (To$ i) (To$ j) (cong₀ To i∼j)
 
-  .fake-at : ∀ i → Setoid ct (suc (ct ⊔ ℓt))
+  fake-at : ∀ i → Setoid ct (suc (ct ⊔ ℓt))
   fake-at i = record
     { Carrier = To$C i
     ; _≈_ = _≈⋆_ {i} {i}

--- a/Categories/Yoneda.agda
+++ b/Categories/Yoneda.agda
@@ -155,7 +155,7 @@ yoneda-iso C c d = record { f = ⇒.η X; g = ⇐.η X;
                             iso = iso X } 
   where
     open NaturalIsomorphism (yoneda C)
-    module iso F,c = Mor.Iso (ISetoids _ _) (iso F,c)
+    module iso F,c = Mor.Iso (iso F,c)
     X = ((Embed.F₀ C d) , c)
 
 
@@ -172,7 +172,7 @@ yoneda-inj C c d ηiso = record { f = ⇒.η c ⟨$⟩ C.id; g = ⇐.η d ⟨$�
     open C.HomReasoning
     module Lemma (c d : C.Obj) (ηiso : NaturalIsomorphism (Embed.F₀ C c) (Embed.F₀ C d)) where
       open NaturalIsomorphism ηiso 
-      module iso c = Mor.Iso _ (iso c)
+      module iso c = Mor.Iso (iso c)
       .lemma : (⇐.η d ⟨$⟩ C.id) C.∘ (⇒.η c ⟨$⟩ C.id) C.≡ C.id
       lemma = begin
                 (⇐.η d ⟨$⟩ C.id) C.∘ (⇒.η c ⟨$⟩ C.id) 


### PR DESCRIPTION
The vast majority of the changes are related to the way that module arguments work -- certain arguments that used to be required are now implicitly given, and must be removed.

The largest 'real' changes are all related to a change in how local functions (defined via 'where') are beta-reduced when they occur in the type of an irrelevant function.  They used to reduce, now they don't, and this leads to things not type checking.  The work-around is to use let definitions, or lift some definitions to be "global" (but private), or to inline a few things.  The latter leads to ugly code, but it is only used once, so not too bad.

The above will be reported as a regression-bug, as soon as I have a small enough case to reproduce it.  But since it might be considered a feature (I hope not), it makes sense to take in these changes now, to make the library work again.  